### PR TITLE
Document roadmap for future milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# artists
-Artist Data Aggregator
+# Artist Data Aggregator API
+
+This project provides a Node.js/Express API that demonstrates how an artist-facing dashboard could aggregate data from several music streaming services. The API exposes endpoints for:
+
+- Listing artists and their high-level metrics.
+- Fetching a detailed overview that includes aggregated performance metrics, audience insights, and content performance.
+- Retrieving the streaming services connected to an artist profile.
+- Updating artist profile information across connected services (mock implementation).
+
+The backend currently uses mocked service responses so it can be explored without connecting to real provider APIs. The structure is designed to make it easy to replace the mocks with production integrations.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v18 or newer
+- [npm](https://www.npmjs.com/)
+
+### Installation
+
+```bash
+npm install
+```
+
+### Running the development server
+
+```bash
+npm run dev
+```
+
+This starts the API on `http://localhost:3000` with auto-reload enabled via `nodemon`.
+
+### Production build
+
+```bash
+npm start
+```
+
+### Tests
+
+The project uses the built-in Node.js test runner. To execute the test suite:
+
+```bash
+npm test
+```
+
+## API Overview
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/` | API health check and endpoint summary. |
+| `GET` | `/artists` | List artists with aggregate metrics. |
+| `GET` | `/artists/:artistId` | Fetch a detailed overview for an artist. |
+| `GET` | `/artists/:artistId/services` | List the connected streaming services. |
+| `PUT` | `/artists/:artistId/profile` | Update an artist profile (mock persistence). |
+
+Example request to fetch the detailed view:
+
+```bash
+curl http://localhost:3000/artists/artist-001 | jq
+```
+
+## Project Structure
+
+```
+.
+├── src
+│   ├── data            # Mock artist and service data
+│   ├── routes          # Express route definitions
+│   ├── services        # Aggregation logic and profile update helpers
+│   └── index.js        # Express application entry point
+├── test                # Node.js test runner suites
+├── package.json        # Project metadata and scripts
+└── README.md           # Project documentation
+```
+
+## Next Steps
+
+An outline of the recommended roadmap is maintained in [`docs/NEXT_STEPS.md`](docs/NEXT_STEPS.md). It expands on the following themes:
+
+- Replacing mocked service data with real provider integrations.
+- Persisting artist profiles and metrics in a relational database such as PostgreSQL.
+- Building a React or Angular front-end that consumes this API and offers configurable dashboards.
+- Adding authentication (OAuth) and role-based access controls for artist teams.
+- Expanding automated test coverage with integration tests against the real providers once available.
+

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,0 +1,34 @@
+# Próximos Passos para o Artist Data Aggregator
+
+Este roteiro detalha a sequência recomendada de atividades para evoluir a API de demonstração para uma plataforma completa.
+
+## 1. Integrações Reais com Serviços de Streaming
+- **Pesquisa de APIs**: documentar requisitos de autenticação e limites de rate para cada provedor (Spotify, Apple, Amazon, Tidal, Deezer).
+- **Módulo de conectores**: criar uma camada de serviços por provedor que normalize respostas para o formato interno.
+- **Gestão de credenciais**: utilizar um cofre seguro (por exemplo, AWS Secrets Manager) e refresh tokens quando aplicável.
+- **Observabilidade**: adicionar logs estruturados e métricas para monitorar latência e falhas em cada integração.
+
+## 2. Persistência de Dados
+- **Modelagem**: desenhar esquema relacional para artistas, serviços conectados, métricas históricas e perfis.
+- **Migrações**: configurar `knex` ou `sequelize` para versionar o banco (PostgreSQL recomendado).
+- **Camada de acesso**: implementar repositórios/DAOs para desacoplar a API da camada de dados.
+- **Rotinas de sincronização**: criar jobs (cron/queue) para atualizar métricas periodicamente e armazenar históricos.
+
+## 3. Autenticação e Autorização
+- **OAuth para artistas**: permitir login via provedores ou credenciais próprias com MFA opcional.
+- **Controle de acesso**: definir papéis (artista, manager, analista) e restringir ações por escopo.
+- **Auditoria**: registrar atividades sensíveis (edições de perfil, exportações de dados).
+
+## 4. Dashboard Web
+- **Frontend**: iniciar um projeto React com TypeScript e design system consistente.
+- **Consumo da API**: construir hooks/serviços para consumir endpoints de métricas e perfis.
+- **Customização**: permitir seleção de widgets e filtros por data/território.
+- **Visualização**: usar bibliotecas de gráficos (Recharts, Victory) para insights de audiência e performance.
+
+## 5. Qualidade e Operação
+- **Testes**: ampliar cobertura com testes de integração (Supertest) e end-to-end (Playwright/Cypress).
+- **CI/CD**: configurar pipeline automatizado (GitHub Actions) com lint, testes e deploy.
+- **Segurança**: executar análises SAST/DAST e aplicar cabeçalhos HTTP de segurança adicionais.
+- **Deploy**: provisionar infraestrutura (Docker/Kubernetes) com monitoramento e alertas.
+
+Cada etapa pode ser priorizada conforme necessidades de negócio, mas a ordem sugerida facilita construir fundações sólidas antes de expandir funcionalidades avançadas.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "artist-data-aggregator",
+  "version": "0.1.0",
+  "description": "Backend API for aggregating artist data from multiple streaming services.",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "artists",
+    "data",
+    "aggregator",
+    "music"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/src/data/artists.js
+++ b/src/data/artists.js
@@ -1,0 +1,15 @@
+export const artists = [
+  {
+    id: 'artist-001',
+    name: 'Lumen Echo',
+    bio: 'Indie electronic producer blending organic instrumentation with synth-driven soundscapes.',
+    profileImage: 'https://example.com/images/lumen-echo-profile.jpg',
+    headerImage: 'https://example.com/images/lumen-echo-header.jpg',
+    socials: {
+      instagram: 'https://instagram.com/lumenecho',
+      twitter: 'https://twitter.com/lumenecho',
+      youtube: 'https://youtube.com/@lumenecho'
+    },
+    services: ['spotify', 'apple', 'tidal']
+  }
+];

--- a/src/data/mockServices.js
+++ b/src/data/mockServices.js
@@ -1,0 +1,91 @@
+export const streamingServices = [
+  {
+    id: 'spotify',
+    name: 'Spotify for Artists',
+    metrics: {
+      streams: 1250000,
+      followers: 48200,
+      revenue: 34000,
+      engagement: {
+        likes: 15200,
+        comments: 830,
+        shares: 1200
+      }
+    },
+    audience: {
+      ageGroups: {
+        '13-17': 0.05,
+        '18-24': 0.32,
+        '25-34': 0.37,
+        '35-44': 0.18,
+        '45+': 0.08
+      },
+      topLocations: ['United States', 'United Kingdom', 'Brazil'],
+      interests: ['Indie Pop', 'Lo-fi', 'Synthwave']
+    },
+    topContent: {
+      tracks: ['Neon Dreams', 'Echoes', 'City Lights'],
+      playlists: ['Chill Vibes', 'Indie Radar'],
+      albums: ['Nightfall']
+    }
+  },
+  {
+    id: 'apple',
+    name: 'Apple for Artists',
+    metrics: {
+      streams: 840000,
+      followers: 22500,
+      revenue: 28500,
+      engagement: {
+        likes: 9600,
+        comments: 410,
+        shares: 680
+      }
+    },
+    audience: {
+      ageGroups: {
+        '13-17': 0.04,
+        '18-24': 0.27,
+        '25-34': 0.41,
+        '35-44': 0.19,
+        '45+': 0.09
+      },
+      topLocations: ['United States', 'Germany', 'Australia'],
+      interests: ['Alt Pop', 'Electronic']
+    },
+    topContent: {
+      tracks: ['City Lights', 'Aurora'],
+      playlists: ['Fresh Finds'],
+      albums: ['Nightfall']
+    }
+  },
+  {
+    id: 'tidal',
+    name: 'Tidal for Artists',
+    metrics: {
+      streams: 265000,
+      followers: 7800,
+      revenue: 13800,
+      engagement: {
+        likes: 2800,
+        comments: 190,
+        shares: 240
+      }
+    },
+    audience: {
+      ageGroups: {
+        '18-24': 0.22,
+        '25-34': 0.38,
+        '35-44': 0.25,
+        '45+': 0.15
+      },
+      topLocations: ['Canada', 'France'],
+      interests: ['Hi-Fi Audio', 'Alternative R&B']
+    },
+    topContent: {
+      tracks: ['Echoes'],
+      playlists: ['Audiophile Essentials'],
+      albums: ['Nightfall']
+    }
+  }
+];

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import artistsRouter from './routes/artists.js';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({
+    status: 'ok',
+    message: 'Artist Data Aggregator API',
+    endpoints: {
+      listArtists: '/artists',
+      artistOverview: '/artists/:artistId',
+      connectedServices: '/artists/:artistId/services',
+      updateProfile: '/artists/:artistId/profile'
+    }
+  });
+});
+
+app.use('/artists', artistsRouter);
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'Route not found' });
+});
+
+app.use((err, req, res, next) => {
+  console.error('Unexpected error', err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Artist Data Aggregator API listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/src/routes/artists.js
+++ b/src/routes/artists.js
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+import {
+  buildArtistOverview,
+  findArtistById,
+  getServicesForArtist,
+  listArtistsWithSummaries
+} from '../services/aggregationService.js';
+import { updateArtistProfile } from '../services/profileService.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  res.json({ data: listArtistsWithSummaries() });
+});
+
+router.get('/:artistId', (req, res) => {
+  const overview = buildArtistOverview(req.params.artistId);
+  if (!overview) {
+    res.status(404).json({ error: 'Artist not found' });
+    return;
+  }
+
+  res.json({ data: overview });
+});
+
+router.get('/:artistId/services', (req, res) => {
+  const artist = findArtistById(req.params.artistId);
+  if (!artist) {
+    res.status(404).json({ error: 'Artist not found' });
+    return;
+  }
+
+  const services = getServicesForArtist(artist).map((service) => ({
+    id: service.id,
+    name: service.name
+  }));
+
+  res.json({ data: services });
+});
+
+router.put('/:artistId/profile', (req, res) => {
+  const { artist, error } = updateArtistProfile(req.params.artistId, req.body ?? {});
+  if (error) {
+    const status = Array.isArray(error) ? 400 : 404;
+    res.status(status).json({ error });
+    return;
+  }
+
+  res.json({ data: buildArtistOverview(artist.id) });
+});
+
+export default router;

--- a/src/services/aggregationService.js
+++ b/src/services/aggregationService.js
@@ -1,0 +1,122 @@
+import { artists } from '../data/artists.js';
+import { streamingServices } from '../data/mockServices.js';
+
+const defaultEngagement = { likes: 0, comments: 0, shares: 0 };
+
+const mergeEngagement = (acc, engagement) => ({
+  likes: acc.likes + (engagement?.likes ?? 0),
+  comments: acc.comments + (engagement?.comments ?? 0),
+  shares: acc.shares + (engagement?.shares ?? 0)
+});
+
+export const findArtistById = (artistId) => artists.find((artist) => artist.id === artistId);
+
+export const getServicesForArtist = (artist) => {
+  if (!artist) return [];
+  return streamingServices.filter((service) => artist.services.includes(service.id));
+};
+
+export const aggregateMetrics = (services) => {
+  return services.reduce(
+    (acc, service) => {
+      const metrics = service.metrics ?? {};
+      return {
+        streams: acc.streams + (metrics.streams ?? 0),
+        followers: acc.followers + (metrics.followers ?? 0),
+        revenue: acc.revenue + (metrics.revenue ?? 0),
+        engagement: mergeEngagement(acc.engagement, metrics.engagement ?? defaultEngagement)
+      };
+    },
+    { streams: 0, followers: 0, revenue: 0, engagement: { ...defaultEngagement } }
+  );
+};
+
+export const aggregateAudienceInsights = (services) => {
+  const ageGroupTotals = {};
+  const ageGroupCounts = {};
+  const locations = new Set();
+  const interests = new Set();
+
+  services.forEach((service) => {
+    const audience = service.audience ?? {};
+    const ageGroups = audience.ageGroups ?? {};
+
+    Object.entries(ageGroups).forEach(([range, percentage]) => {
+      if (typeof percentage !== 'number') return;
+      ageGroupTotals[range] = (ageGroupTotals[range] ?? 0) + percentage;
+      ageGroupCounts[range] = (ageGroupCounts[range] ?? 0) + 1;
+    });
+
+    (audience.topLocations ?? []).forEach((location) => locations.add(location));
+    (audience.interests ?? []).forEach((interest) => interests.add(interest));
+  });
+
+  const ageGroupAverages = Object.entries(ageGroupTotals).reduce((acc, [range, total]) => {
+    const count = ageGroupCounts[range] ?? 1;
+    acc[range] = parseFloat((total / count).toFixed(2));
+    return acc;
+  }, {});
+
+  return {
+    ageGroups: ageGroupAverages,
+    topLocations: Array.from(locations),
+    interests: Array.from(interests)
+  };
+};
+
+export const aggregateContentPerformance = (services) => {
+  const tracks = new Set();
+  const albums = new Set();
+  const playlists = new Set();
+
+  services.forEach((service) => {
+    const topContent = service.topContent ?? {};
+    (topContent.tracks ?? []).forEach((track) => tracks.add(track));
+    (topContent.albums ?? []).forEach((album) => albums.add(album));
+    (topContent.playlists ?? []).forEach((playlist) => playlists.add(playlist));
+  });
+
+  return {
+    tracks: Array.from(tracks),
+    albums: Array.from(albums),
+    playlists: Array.from(playlists)
+  };
+};
+
+export const buildArtistOverview = (artistId) => {
+  const artist = findArtistById(artistId);
+  if (!artist) return null;
+
+  const services = getServicesForArtist(artist);
+  const metrics = aggregateMetrics(services);
+  const audience = aggregateAudienceInsights(services);
+  const content = aggregateContentPerformance(services);
+
+  return {
+    ...artist,
+    metrics,
+    audience,
+    content,
+    services: services.map((service) => ({
+      id: service.id,
+      name: service.name,
+      metrics: service.metrics
+    }))
+  };
+};
+
+export const listArtistsWithSummaries = () =>
+  artists.map((artist) => {
+    const services = getServicesForArtist(artist);
+    const metrics = aggregateMetrics(services);
+    return {
+      id: artist.id,
+      name: artist.name,
+      profileImage: artist.profileImage,
+      metrics: {
+        streams: metrics.streams,
+        followers: metrics.followers,
+        revenue: metrics.revenue
+      }
+    };
+  });

--- a/src/services/profileService.js
+++ b/src/services/profileService.js
@@ -1,0 +1,124 @@
+import { artists } from '../data/artists.js';
+
+const allowedFields = new Set(['name', 'bio', 'profileImage', 'headerImage', 'socials']);
+const socialFields = ['instagram', 'twitter', 'youtube', 'facebook', 'tiktok', 'website'];
+
+const isString = (value) => typeof value === 'string';
+
+const isValidUrl = (value) => {
+  try {
+    new URL(value);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const validateProfileUpdates = (updates) => {
+  if (updates === null || typeof updates !== 'object' || Array.isArray(updates)) {
+    return ['Profile updates must be provided as an object.'];
+  }
+
+  const keys = Object.keys(updates);
+  if (keys.length === 0) {
+    return ['Provide at least one field to update.'];
+  }
+
+  const errors = [];
+
+  keys.forEach((key) => {
+    if (!allowedFields.has(key)) {
+      errors.push(`"${key}" is not a supported profile field.`);
+    }
+  });
+
+  if (updates.name !== undefined) {
+    if (!isString(updates.name)) {
+      errors.push('Name must be a string.');
+    } else if (updates.name.trim().length < 2 || updates.name.trim().length > 120) {
+      errors.push('Name must be between 2 and 120 characters.');
+    }
+  }
+
+  if (updates.bio !== undefined) {
+    if (!isString(updates.bio)) {
+      errors.push('Bio must be a string.');
+    } else if (updates.bio.length > 1000) {
+      errors.push('Bio must be 1000 characters or fewer.');
+    }
+  }
+
+  const validateImageField = (fieldName) => {
+    const value = updates[fieldName];
+    if (value === undefined) return;
+    if (!isString(value)) {
+      errors.push(`${fieldName} must be a string URL.`);
+      return;
+    }
+    if (!isValidUrl(value)) {
+      errors.push(`${fieldName} must be a valid URL.`);
+    }
+  };
+
+  validateImageField('profileImage');
+  validateImageField('headerImage');
+
+  if (updates.socials !== undefined) {
+    const socials = updates.socials;
+    if (socials === null || typeof socials !== 'object' || Array.isArray(socials)) {
+      errors.push('Social links must be provided as an object.');
+    } else {
+      const socialKeys = Object.keys(socials);
+      if (socialKeys.length === 0) {
+        errors.push('Provide at least one social link to update.');
+      }
+
+      socialKeys.forEach((socialKey) => {
+        if (!socialFields.includes(socialKey)) {
+          errors.push(`"${socialKey}" is not a supported social profile.`);
+          return;
+        }
+
+        const value = socials[socialKey];
+        if (!isString(value)) {
+          errors.push(`${socialKey} link must be a string.`);
+        } else if (!isValidUrl(value)) {
+          errors.push(`${socialKey} link must be a valid URL.`);
+        }
+      });
+    }
+  }
+
+  return errors;
+};
+
+export const updateArtistProfile = (artistId, updates) => {
+  const artistIndex = artists.findIndex((artist) => artist.id === artistId);
+  if (artistIndex === -1) {
+    return { artist: null, error: `Artist with id "${artistId}" was not found.` };
+  }
+
+  const validationErrors = validateProfileUpdates(updates);
+  if (validationErrors.length > 0) {
+    return {
+      artist: null,
+      error: validationErrors
+    };
+  }
+
+  const artist = artists[artistIndex];
+  const mergedSocials =
+    updates.socials !== undefined
+      ? { ...artist.socials, ...updates.socials }
+      : artist.socials;
+
+  const merged = {
+    ...artist,
+    ...updates,
+    socials: mergedSocials
+  };
+
+  artists[artistIndex] = merged;
+
+  return { artist: merged, error: null };
+};

--- a/test/aggregation.test.js
+++ b/test/aggregation.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  aggregateAudienceInsights,
+  aggregateContentPerformance,
+  aggregateMetrics,
+  buildArtistOverview,
+  findArtistById,
+  getServicesForArtist,
+  listArtistsWithSummaries
+} from '../src/services/aggregationService.js';
+
+import { streamingServices } from '../src/data/mockServices.js';
+
+test('findArtistById returns an existing artist', () => {
+  const artist = findArtistById('artist-001');
+  assert.ok(artist, 'Expected artist to be found');
+  assert.equal(artist.name, 'Lumen Echo');
+});
+
+test('getServicesForArtist returns configured services', () => {
+  const artist = findArtistById('artist-001');
+  const services = getServicesForArtist(artist);
+  const serviceIds = services.map((service) => service.id);
+  assert.deepEqual(serviceIds.sort(), ['apple', 'spotify', 'tidal']);
+});
+
+test('aggregateMetrics sums streams, followers, revenue, and engagement', () => {
+  const metrics = aggregateMetrics(streamingServices);
+  assert.equal(metrics.streams, 1250000 + 840000 + 265000);
+  assert.equal(metrics.followers, 48200 + 22500 + 7800);
+  assert.equal(metrics.revenue, 34000 + 28500 + 13800);
+  assert.deepEqual(metrics.engagement, {
+    likes: 15200 + 9600 + 2800,
+    comments: 830 + 410 + 190,
+    shares: 1200 + 680 + 240
+  });
+});
+
+test('aggregateAudienceInsights averages percentages and merges sets', () => {
+  const audience = aggregateAudienceInsights(streamingServices);
+  assert.equal(audience.ageGroups['18-24'], parseFloat(((0.32 + 0.27 + 0.22) / 3).toFixed(2)));
+  assert.ok(audience.topLocations.includes('United States'));
+  assert.ok(audience.interests.includes('Indie Pop'));
+});
+
+test('aggregateAudienceInsights ignores missing data when averaging', () => {
+  const services = [
+    { audience: { ageGroups: { '13-17': 0.12 } } },
+    { audience: { ageGroups: {} } }
+  ];
+
+  const audience = aggregateAudienceInsights(services);
+  assert.equal(audience.ageGroups['13-17'], 0.12);
+});
+
+test('aggregateContentPerformance merges unique content across services', () => {
+  const content = aggregateContentPerformance(streamingServices);
+  assert.ok(content.tracks.includes('Neon Dreams'));
+  assert.ok(content.tracks.includes('Aurora'));
+  assert.ok(content.playlists.includes('Indie Radar'));
+});
+
+test('buildArtistOverview returns aggregated data for artist', () => {
+  const overview = buildArtistOverview('artist-001');
+  assert.equal(overview.id, 'artist-001');
+  assert.equal(overview.metrics.streams, 1250000 + 840000 + 265000);
+  assert.equal(overview.content.tracks.length > 0, true);
+});
+
+test('listArtistsWithSummaries returns summary info', () => {
+  const summaries = listArtistsWithSummaries();
+  assert.equal(summaries.length, 1);
+  assert.equal(summaries[0].id, 'artist-001');
+});

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { artists } from '../src/data/artists.js';
+import { updateArtistProfile } from '../src/services/profileService.js';
+
+const originalArtists = structuredClone(artists);
+
+const resetArtists = () => {
+  artists.length = 0;
+  artists.push(...structuredClone(originalArtists));
+};
+
+test('updateArtistProfile rejects empty payloads', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', {});
+  assert.equal(result.artist, null);
+  assert.ok(Array.isArray(result.error));
+  assert.ok(result.error.some((message) => message.toLowerCase().includes('at least one field')));
+});
+
+test('updateArtistProfile validates social handles object is not empty', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', { socials: {} });
+  assert.equal(result.artist, null);
+  assert.ok(result.error.some((message) => message.toLowerCase().includes('social link')));
+});
+
+test('updateArtistProfile merges social links when valid', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', {
+    socials: { instagram: 'https://instagram.com/new-handle' }
+  });
+
+  assert.equal(result.error, null);
+  assert.equal(result.artist.socials.instagram, 'https://instagram.com/new-handle');
+  assert.equal(result.artist.socials.youtube, originalArtists[0].socials.youtube);
+});
+
+test('updateArtistProfile leaves existing socials untouched when not provided', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', {
+    bio: 'Updated bio only'
+  });
+
+  assert.equal(result.error, null);
+  assert.equal(result.artist.bio, 'Updated bio only');
+  assert.deepEqual(result.artist.socials, originalArtists[0].socials);
+});


### PR DESCRIPTION
## Summary
- add a Portuguese roadmap outlining integration, persistence, auth, frontend, and operations milestones
- link the README next steps section to the detailed roadmap document

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dffbc657dc83239e6e0b7f82c4e4a9