### PR TITLE
Finalize mock API with multi-artist data and dashboard customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
-# artists
-Artist Data Aggregator
+# Artist Data Aggregator API
+
+This project provides a Node.js/Express API that demonstrates how an artist-facing dashboard could aggregate data from several music streaming services. The mock dataset inclui três artistas conectados a Spotify for Artists, Apple for Artists, Amazon for Artists, Tidal for Artists e Deezer for Creators, permitindo validar o fluxo de ponta a ponta. A API expõe endpoints para:
+
+- Listar artistas com métricas consolidadas e destaques de insights.
+- Obter um overview detalhado com métricas agregadas, insights de audiência, performance de conteúdo e tendências temporais.
+- Consultar os serviços conectados a um artista com métricas individuais por plataforma.
+- Atualizar as informações de perfil dos artistas (implementação mock).
+- Ler e personalizar os widgets exibidos no dashboard do artista.
+
+The backend currently uses mocked service responses so it can be explored without connecting to real provider APIs. The structure is designed to make it easy to replace the mocks with production integrations.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) v18 or newer
+- [npm](https://www.npmjs.com/)
+
+### Installation
+
+```bash
+npm install
+```
+
+### Running the development server
+
+```bash
+npm run dev
+```
+
+This starts the API on `http://localhost:3000` with auto-reload enabled via `nodemon`.
+
+### Production build
+
+```bash
+npm start
+```
+
+### Tests
+
+The project uses the built-in Node.js test runner. To execute the test suite:
+
+```bash
+npm test
+```
+
+## API Overview
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/` | API health check and endpoint summary. |
+| `GET` | `/artists` | List artists with aggregate metrics. |
+| `GET` | `/artists/:artistId` | Fetch a detailed overview for an artist. |
+| `GET` | `/artists/:artistId/services` | List the connected streaming services com métricas por plataforma. |
+| `GET` | `/artists/:artistId/metrics` | Obter séries temporais agregadas e estatísticas resumidas opcionamente filtradas por intervalo de datas. |
+| `GET` | `/artists/:artistId/dashboard` | Obter o layout do dashboard e o catálogo de widgets disponíveis. |
+| `PUT` | `/artists/:artistId/dashboard` | Atualizar a ordem de widgets do dashboard (mock persistence). |
+| `PUT` | `/artists/:artistId/profile` | Update an artist profile (mock persistence). |
+
+Example request to fetch the detailed view:
+
+```bash
+curl http://localhost:3000/artists/artist-001 | jq
+```
+
+Customizando o dashboard de `artist-001`:
+
+```bash
+curl -X PUT http://localhost:3000/artists/artist-001/dashboard \
+  -H 'Content-Type: application/json' \
+  -d '{"layout": ["overview", "streams-over-time", "top-content"]}' | jq
+```
+
+Consultando métricas agregadas de `artist-002` apenas para o último trimestre disponível:
+
+```bash
+curl "http://localhost:3000/artists/artist-002/metrics?start=2023-10-01&end=2024-01-01" | jq
+```
+
+O endpoint aceita os parâmetros opcionais `start` e `end` (formato `YYYY-MM-DD`). Quando fornecidos, o período é aplicado a todas as séries e as estatísticas retornadas refletem apenas o intervalo solicitado.
+
+## Project Structure
+
+```
+.
+├── src
+│   ├── data            # Mock artist and service data
+│   ├── routes          # Express route definitions
+│   ├── services        # Aggregation logic and profile update helpers
+│   └── index.js        # Express application entry point
+├── test                # Node.js test runner suites
+├── package.json        # Project metadata and scripts
+└── README.md           # Project documentation
+```
+
+## Next Steps
+
+An outline of the recommended roadmap is maintained in [`docs/NEXT_STEPS.md`](docs/NEXT_STEPS.md). It expands on the following themes:
+
+- Replacing mocked service data with real provider integrations.
+- Persisting artist profiles and metrics in a relational database such as PostgreSQL.
+- Building a React or Angular front-end that consumes this API and offers configurable dashboards.
+- Adding authentication (OAuth) and role-based access controls for artist teams.
+- Expanding automated test coverage with integration tests against the real providers once available.
+

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,0 +1,34 @@
+# Próximos Passos para o Artist Data Aggregator
+
+Este roteiro detalha a sequência recomendada de atividades para evoluir a API de demonstração para uma plataforma completa.
+
+## 1. Integrações Reais com Serviços de Streaming
+- **Pesquisa de APIs**: documentar requisitos de autenticação e limites de rate para cada provedor (Spotify, Apple, Amazon, Tidal, Deezer).
+- **Módulo de conectores**: criar uma camada de serviços por provedor que normalize respostas para o formato interno.
+- **Gestão de credenciais**: utilizar um cofre seguro (por exemplo, AWS Secrets Manager) e refresh tokens quando aplicável.
+- **Observabilidade**: adicionar logs estruturados e métricas para monitorar latência e falhas em cada integração.
+
+## 2. Persistência de Dados
+- **Modelagem**: desenhar esquema relacional para artistas, serviços conectados, métricas históricas e perfis.
+- **Migrações**: configurar `knex` ou `sequelize` para versionar o banco (PostgreSQL recomendado).
+- **Camada de acesso**: implementar repositórios/DAOs para desacoplar a API da camada de dados.
+- **Rotinas de sincronização**: criar jobs (cron/queue) para atualizar métricas periodicamente e armazenar históricos.
+
+## 3. Autenticação e Autorização
+- **OAuth para artistas**: permitir login via provedores ou credenciais próprias com MFA opcional.
+- **Controle de acesso**: definir papéis (artista, manager, analista) e restringir ações por escopo.
+- **Auditoria**: registrar atividades sensíveis (edições de perfil, exportações de dados).
+
+## 4. Dashboard Web
+- **Frontend**: iniciar um projeto React com TypeScript e design system consistente.
+- **Consumo da API**: construir hooks/serviços para consumir endpoints de métricas e perfis.
+- **Customização**: permitir seleção de widgets e filtros por data/território.
+- **Visualização**: usar bibliotecas de gráficos (Recharts, Victory) para insights de audiência e performance.
+
+## 5. Qualidade e Operação
+- **Testes**: ampliar cobertura com testes de integração (Supertest) e end-to-end (Playwright/Cypress).
+- **CI/CD**: configurar pipeline automatizado (GitHub Actions) com lint, testes e deploy.
+- **Segurança**: executar análises SAST/DAST e aplicar cabeçalhos HTTP de segurança adicionais.
+- **Deploy**: provisionar infraestrutura (Docker/Kubernetes) com monitoramento e alertas.
+
+Cada etapa pode ser priorizada conforme necessidades de negócio, mas a ordem sugerida facilita construir fundações sólidas antes de expandir funcionalidades avançadas.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "artist-data-aggregator",
+  "version": "0.1.0",
+  "description": "Backend API for aggregating artist data from multiple streaming services.",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "artists",
+    "data",
+    "aggregator",
+    "music"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "helmet": "^7.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/src/data/artists.js
+++ b/src/data/artists.js
@@ -1,0 +1,41 @@
+export const artists = [
+  {
+    id: 'artist-001',
+    name: 'Lumen Echo',
+    bio: 'Indie electronic producer blending organic instrumentation with synth-driven soundscapes.',
+    profileImage: 'https://example.com/images/lumen-echo-profile.jpg',
+    headerImage: 'https://example.com/images/lumen-echo-header.jpg',
+    socials: {
+      instagram: 'https://instagram.com/lumenecho',
+      twitter: 'https://twitter.com/lumenecho',
+      youtube: 'https://youtube.com/@lumenecho'
+    },
+    services: ['spotify', 'apple', 'tidal']
+  },
+  {
+    id: 'artist-002',
+    name: 'Solaris Pulse',
+    bio: 'Electronic duo combining pulsating basslines with cinematic atmospheres for festival stages.',
+    profileImage: 'https://example.com/images/solaris-pulse-profile.jpg',
+    headerImage: 'https://example.com/images/solaris-pulse-header.jpg',
+    socials: {
+      instagram: 'https://instagram.com/solarispulse',
+      twitter: 'https://twitter.com/solaris_pulse',
+      facebook: 'https://facebook.com/solarisPulseOfficial'
+    },
+    services: ['spotify', 'amazon', 'deezer']
+  },
+  {
+    id: 'artist-003',
+    name: 'Velvet Horizons',
+    bio: 'Dream pop trio crafting lush vocal harmonies and retro-futuristic arrangements.',
+    profileImage: 'https://example.com/images/velvet-horizons-profile.jpg',
+    headerImage: 'https://example.com/images/velvet-horizons-header.jpg',
+    socials: {
+      instagram: 'https://instagram.com/velvethorizons',
+      tiktok: 'https://tiktok.com/@velvethorizons',
+      website: 'https://velvethorizons.example.com'
+    },
+    services: ['apple', 'tidal', 'deezer']
+  }
+];

--- a/src/data/dashboards.js
+++ b/src/data/dashboards.js
@@ -1,0 +1,48 @@
+export const widgetCatalog = [
+  {
+    id: 'overview',
+    name: 'Resumo Geral',
+    description: 'Exibe streams, seguidores, receita e engajamento consolidados.',
+    type: 'summary'
+  },
+  {
+    id: 'streams-over-time',
+    name: 'Streams ao Longo do Tempo',
+    description: 'Comparativo mensal de streams agregados entre os serviços.',
+    type: 'timeseries',
+    metric: 'streams'
+  },
+  {
+    id: 'revenue-over-time',
+    name: 'Receita ao Longo do Tempo',
+    description: 'Curva de receita combinada para monitorar crescimento financeiro.',
+    type: 'timeseries',
+    metric: 'revenue'
+  },
+  {
+    id: 'audience-demographics',
+    name: 'Demografia do Público',
+    description: 'Faixas etárias e interesses predominantes por audiência.',
+    type: 'audience'
+  },
+  {
+    id: 'top-locations',
+    name: 'Principais Territórios',
+    description: 'Locais com maior audiência considerando todos os serviços.',
+    type: 'list'
+  },
+  {
+    id: 'top-content',
+    name: 'Conteúdo em Destaque',
+    description: 'Faixas, álbuns e playlists com melhor desempenho recente.',
+    type: 'list'
+  }
+];
+
+export const defaultLayout = ['overview', 'streams-over-time', 'audience-demographics', 'top-content'];
+
+export const initialDashboardLayouts = {
+  'artist-001': ['overview', 'streams-over-time', 'revenue-over-time', 'top-content', 'top-locations'],
+  'artist-002': ['overview', 'streams-over-time', 'audience-demographics', 'top-content'],
+  'artist-003': ['overview', 'streams-over-time', 'revenue-over-time', 'audience-demographics', 'top-locations']
+};

--- a/src/data/mockServices.js
+++ b/src/data/mockServices.js
@@ -1,0 +1,480 @@
+export const streamingServices = [
+  {
+    id: 'spotify',
+    name: 'Spotify for Artists',
+    artists: {
+      'artist-001': {
+        metrics: {
+          streams: 1250000,
+          followers: 48200,
+          revenue: 34000,
+          engagement: {
+            likes: 15200,
+            comments: 830,
+            shares: 1200
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.05,
+            '18-24': 0.32,
+            '25-34': 0.37,
+            '35-44': 0.18,
+            '45+': 0.08
+          },
+          topLocations: ['United States', 'United Kingdom', 'Brazil'],
+          interests: ['Indie Pop', 'Lo-fi', 'Synthwave']
+        },
+        topContent: {
+          tracks: ['Neon Dreams', 'Echoes', 'City Lights'],
+          playlists: ['Chill Vibes', 'Indie Radar'],
+          albums: ['Nightfall']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 42000 },
+            { date: '2023-09-01', value: 47000 },
+            { date: '2023-10-01', value: 52000 },
+            { date: '2023-11-01', value: 61000 },
+            { date: '2023-12-01', value: 67000 },
+            { date: '2024-01-01', value: 72000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 38000 },
+            { date: '2023-10-01', value: 42000 },
+            { date: '2023-12-01', value: 45500 },
+            { date: '2024-01-01', value: 48200 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 4200 },
+            { date: '2023-10-01', value: 5200 },
+            { date: '2023-12-01', value: 6200 },
+            { date: '2024-01-01', value: 6900 }
+          ]
+        }
+      },
+      'artist-002': {
+        metrics: {
+          streams: 980000,
+          followers: 36500,
+          revenue: 27600,
+          engagement: {
+            likes: 11800,
+            comments: 610,
+            shares: 960
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.07,
+            '18-24': 0.34,
+            '25-34': 0.36,
+            '35-44': 0.17,
+            '45+': 0.06
+          },
+          topLocations: ['United States', 'Mexico', 'Spain'],
+          interests: ['Festival EDM', 'Synthwave']
+        },
+        topContent: {
+          tracks: ['Solar Flare', 'Midnight Pulse'],
+          playlists: ['Dance Rising', 'Festival Anthems'],
+          albums: ['Horizons Awake']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 35000 },
+            { date: '2023-09-01', value: 39000 },
+            { date: '2023-10-01', value: 43000 },
+            { date: '2023-11-01', value: 47000 },
+            { date: '2023-12-01', value: 52000 },
+            { date: '2024-01-01', value: 56000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 28500 },
+            { date: '2023-10-01', value: 32000 },
+            { date: '2023-12-01', value: 34800 },
+            { date: '2024-01-01', value: 36500 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 3300 },
+            { date: '2023-10-01', value: 4200 },
+            { date: '2023-12-01', value: 4800 },
+            { date: '2024-01-01', value: 5200 }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'apple',
+    name: 'Apple for Artists',
+    artists: {
+      'artist-001': {
+        metrics: {
+          streams: 840000,
+          followers: 22500,
+          revenue: 28500,
+          engagement: {
+            likes: 9600,
+            comments: 410,
+            shares: 680
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.04,
+            '18-24': 0.27,
+            '25-34': 0.41,
+            '35-44': 0.19,
+            '45+': 0.09
+          },
+          topLocations: ['United States', 'Germany', 'Australia'],
+          interests: ['Alt Pop', 'Electronic']
+        },
+        topContent: {
+          tracks: ['City Lights', 'Aurora'],
+          playlists: ['Fresh Finds'],
+          albums: ['Nightfall']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 30000 },
+            { date: '2023-09-01', value: 33000 },
+            { date: '2023-10-01', value: 36000 },
+            { date: '2023-11-01', value: 41000 },
+            { date: '2023-12-01', value: 44000 },
+            { date: '2024-01-01', value: 47000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 19000 },
+            { date: '2023-10-01', value: 20500 },
+            { date: '2023-12-01', value: 21800 },
+            { date: '2024-01-01', value: 22500 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 3600 },
+            { date: '2023-10-01', value: 4200 },
+            { date: '2023-12-01', value: 4700 },
+            { date: '2024-01-01', value: 5100 }
+          ]
+        }
+      },
+      'artist-003': {
+        metrics: {
+          streams: 720000,
+          followers: 19800,
+          revenue: 24100,
+          engagement: {
+            likes: 8400,
+            comments: 520,
+            shares: 740
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.06,
+            '18-24': 0.29,
+            '25-34': 0.38,
+            '35-44': 0.19,
+            '45+': 0.08
+          },
+          topLocations: ['Canada', 'United Kingdom', 'Netherlands'],
+          interests: ['Dream Pop', 'Shoegaze']
+        },
+        topContent: {
+          tracks: ['Velvet Skies', 'Chromatic Wave'],
+          playlists: ['Dream Pop Essentials'],
+          albums: ['Lunar Bloom']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 26000 },
+            { date: '2023-09-01', value: 28000 },
+            { date: '2023-10-01', value: 32000 },
+            { date: '2023-11-01', value: 35000 },
+            { date: '2023-12-01', value: 38000 },
+            { date: '2024-01-01', value: 42000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 15200 },
+            { date: '2023-10-01', value: 17000 },
+            { date: '2023-12-01', value: 18600 },
+            { date: '2024-01-01', value: 19800 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 2800 },
+            { date: '2023-10-01', value: 3200 },
+            { date: '2023-12-01', value: 3600 },
+            { date: '2024-01-01', value: 3900 }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'tidal',
+    name: 'Tidal for Artists',
+    artists: {
+      'artist-001': {
+        metrics: {
+          streams: 265000,
+          followers: 7800,
+          revenue: 13800,
+          engagement: {
+            likes: 2800,
+            comments: 190,
+            shares: 240
+          }
+        },
+        audience: {
+          ageGroups: {
+            '18-24': 0.22,
+            '25-34': 0.38,
+            '35-44': 0.25,
+            '45+': 0.15
+          },
+          topLocations: ['Canada', 'France'],
+          interests: ['Hi-Fi Audio', 'Alternative R&B']
+        },
+        topContent: {
+          tracks: ['Echoes'],
+          playlists: ['Audiophile Essentials'],
+          albums: ['Nightfall']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 9000 },
+            { date: '2023-09-01', value: 9500 },
+            { date: '2023-10-01', value: 10200 },
+            { date: '2023-11-01', value: 11000 },
+            { date: '2023-12-01', value: 12000 },
+            { date: '2024-01-01', value: 13000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 6400 },
+            { date: '2023-10-01', value: 7000 },
+            { date: '2023-12-01', value: 7500 },
+            { date: '2024-01-01', value: 7800 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 2200 },
+            { date: '2023-10-01', value: 2600 },
+            { date: '2023-12-01', value: 3000 },
+            { date: '2024-01-01', value: 3300 }
+          ]
+        }
+      },
+      'artist-003': {
+        metrics: {
+          streams: 198000,
+          followers: 6300,
+          revenue: 11200,
+          engagement: {
+            likes: 2100,
+            comments: 160,
+            shares: 190
+          }
+        },
+        audience: {
+          ageGroups: {
+            '18-24': 0.18,
+            '25-34': 0.36,
+            '35-44': 0.28,
+            '45+': 0.18
+          },
+          topLocations: ['United States', 'Sweden'],
+          interests: ['Vinyl Collectors', 'Indie Pop']
+        },
+        topContent: {
+          tracks: ['Chromatic Wave'],
+          playlists: ['Indie Discovery'],
+          albums: ['Lunar Bloom']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 6200 },
+            { date: '2023-09-01', value: 6600 },
+            { date: '2023-10-01', value: 7200 },
+            { date: '2023-11-01', value: 7800 },
+            { date: '2023-12-01', value: 8200 },
+            { date: '2024-01-01', value: 8600 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 5200 },
+            { date: '2023-10-01', value: 5800 },
+            { date: '2023-12-01', value: 6100 },
+            { date: '2024-01-01', value: 6300 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 1800 },
+            { date: '2023-10-01', value: 2100 },
+            { date: '2023-12-01', value: 2400 },
+            { date: '2024-01-01', value: 2600 }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'amazon',
+    name: 'Amazon for Artists',
+    artists: {
+      'artist-002': {
+        metrics: {
+          streams: 540000,
+          followers: 18200,
+          revenue: 19800,
+          engagement: {
+            likes: 6400,
+            comments: 320,
+            shares: 510
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.05,
+            '18-24': 0.31,
+            '25-34': 0.4,
+            '35-44': 0.17,
+            '45+': 0.07
+          },
+          topLocations: ['United States', 'Japan'],
+          interests: ['Bass Music', 'Gaming']
+        },
+        topContent: {
+          tracks: ['Pulse Driver', 'Aurora Run'],
+          playlists: ['EDM Now'],
+          albums: ['Horizons Awake']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 18000 },
+            { date: '2023-09-01', value: 21000 },
+            { date: '2023-10-01', value: 24000 },
+            { date: '2023-11-01', value: 26000 },
+            { date: '2023-12-01', value: 28000 },
+            { date: '2024-01-01', value: 30000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 14000 },
+            { date: '2023-10-01', value: 16000 },
+            { date: '2023-12-01', value: 17400 },
+            { date: '2024-01-01', value: 18200 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 2400 },
+            { date: '2023-10-01', value: 2900 },
+            { date: '2023-12-01', value: 3300 },
+            { date: '2024-01-01', value: 3600 }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'deezer',
+    name: 'Deezer for Creators',
+    artists: {
+      'artist-002': {
+        metrics: {
+          streams: 305000,
+          followers: 12900,
+          revenue: 9400,
+          engagement: {
+            likes: 4100,
+            comments: 210,
+            shares: 340
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.08,
+            '18-24': 0.33,
+            '25-34': 0.35,
+            '35-44': 0.17,
+            '45+': 0.07
+          },
+          topLocations: ['France', 'Brazil'],
+          interests: ['Electro Pop', 'Workout Playlists']
+        },
+        topContent: {
+          tracks: ['Solar Flare'],
+          playlists: ['Cardio Boost'],
+          albums: ['Horizons Awake']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 11000 },
+            { date: '2023-09-01', value: 12500 },
+            { date: '2023-10-01', value: 14000 },
+            { date: '2023-11-01', value: 15500 },
+            { date: '2023-12-01', value: 17000 },
+            { date: '2024-01-01', value: 18000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 9800 },
+            { date: '2023-10-01', value: 11400 },
+            { date: '2023-12-01', value: 12300 },
+            { date: '2024-01-01', value: 12900 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 1500 },
+            { date: '2023-10-01', value: 2100 },
+            { date: '2023-12-01', value: 2500 },
+            { date: '2024-01-01', value: 2800 }
+          ]
+        }
+      },
+      'artist-003': {
+        metrics: {
+          streams: 256000,
+          followers: 11100,
+          revenue: 8200,
+          engagement: {
+            likes: 3600,
+            comments: 240,
+            shares: 310
+          }
+        },
+        audience: {
+          ageGroups: {
+            '13-17': 0.09,
+            '18-24': 0.31,
+            '25-34': 0.33,
+            '35-44': 0.17,
+            '45+': 0.1
+          },
+          topLocations: ['Brazil', 'Portugal'],
+          interests: ['Chillwave', 'Late Night Drives']
+        },
+        topContent: {
+          tracks: ['Velvet Skies'],
+          playlists: ['Focus Flow'],
+          albums: ['Lunar Bloom']
+        },
+        trends: {
+          streams: [
+            { date: '2023-08-01', value: 9000 },
+            { date: '2023-09-01', value: 10200 },
+            { date: '2023-10-01', value: 11800 },
+            { date: '2023-11-01', value: 13000 },
+            { date: '2023-12-01', value: 14200 },
+            { date: '2024-01-01', value: 15000 }
+          ],
+          followers: [
+            { date: '2023-08-01', value: 8600 },
+            { date: '2023-10-01', value: 9600 },
+            { date: '2023-12-01', value: 10400 },
+            { date: '2024-01-01', value: 11100 }
+          ],
+          revenue: [
+            { date: '2023-08-01', value: 1300 },
+            { date: '2023-10-01', value: 1700 },
+            { date: '2023-12-01', value: 2100 },
+            { date: '2024-01-01', value: 2300 }
+          ]
+        }
+      }
+    }
+  }
+];

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import artistsRouter from './routes/artists.js';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({
+    status: 'ok',
+    message: 'Artist Data Aggregator API',
+    endpoints: {
+      listArtists: '/artists',
+      artistOverview: '/artists/:artistId',
+      connectedServices: '/artists/:artistId/services',
+      aggregatedMetrics: '/artists/:artistId/metrics',
+      dashboardLayout: '/artists/:artistId/dashboard',
+      updateProfile: '/artists/:artistId/profile'
+    }
+  });
+});
+
+app.use('/artists', artistsRouter);
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'Route not found' });
+});
+
+app.use((err, req, res, next) => {
+  console.error('Unexpected error', err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`Artist Data Aggregator API listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/src/routes/artists.js
+++ b/src/routes/artists.js
@@ -1,0 +1,121 @@
+import { Router } from 'express';
+import {
+  buildArtistOverview,
+  findArtistById,
+  getServicesForArtist,
+  listArtistsWithSummaries,
+  buildArtistMetricsSnapshot
+} from '../services/aggregationService.js';
+import { getDashboard, updateDashboard } from '../services/dashboardService.js';
+import { updateArtistProfile } from '../services/profileService.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  res.json({ data: listArtistsWithSummaries() });
+});
+
+router.get('/:artistId', (req, res) => {
+  const overview = buildArtistOverview(req.params.artistId);
+  if (!overview) {
+    res.status(404).json({ error: 'Artist not found' });
+    return;
+  }
+
+  res.json({ data: overview });
+});
+
+router.get('/:artistId/services', (req, res) => {
+  const artist = findArtistById(req.params.artistId);
+  if (!artist) {
+    res.status(404).json({ error: 'Artist not found' });
+    return;
+  }
+
+  const services = getServicesForArtist(artist).map((service) => ({
+    id: service.id,
+    name: service.name,
+    metrics: service.metrics,
+    audience: service.audience,
+    topContent: service.topContent,
+    trends: service.trends
+  }));
+
+  res.json({ data: services });
+});
+
+router.get('/:artistId/metrics', (req, res) => {
+  const { start, end } = req.query;
+
+  const parseDateParam = (value) => {
+    if (value === undefined) return null;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return { error: `Invalid date value "${value}". Use ISO format (YYYY-MM-DD).` };
+    }
+    return { date: parsed };
+  };
+
+  const startResult = parseDateParam(start);
+  if (startResult?.error) {
+    res.status(400).json({ error: startResult.error });
+    return;
+  }
+
+  const endResult = parseDateParam(end);
+  if (endResult?.error) {
+    res.status(400).json({ error: endResult.error });
+    return;
+  }
+
+  if (startResult?.date && endResult?.date && startResult.date > endResult.date) {
+    res.status(400).json({ error: 'The start date must be before or equal to the end date.' });
+    return;
+  }
+
+  const snapshot = buildArtistMetricsSnapshot(req.params.artistId, {
+    startDate: startResult?.date ?? null,
+    endDate: endResult?.date ?? null
+  });
+
+  if (!snapshot) {
+    res.status(404).json({ error: 'Artist not found' });
+    return;
+  }
+
+  res.json({ data: snapshot });
+});
+
+router.get('/:artistId/dashboard', (req, res) => {
+  const { dashboard, error } = getDashboard(req.params.artistId);
+  if (error) {
+    res.status(404).json({ error });
+    return;
+  }
+
+  res.json({ data: dashboard });
+});
+
+router.put('/:artistId/dashboard', (req, res) => {
+  const { dashboard, error } = updateDashboard(req.params.artistId, req.body ?? {});
+  if (error) {
+    const status = Array.isArray(error) ? 400 : 404;
+    res.status(status).json({ error });
+    return;
+  }
+
+  res.json({ data: dashboard });
+});
+
+router.put('/:artistId/profile', (req, res) => {
+  const { artist, error } = updateArtistProfile(req.params.artistId, req.body ?? {});
+  if (error) {
+    const status = Array.isArray(error) ? 400 : 404;
+    res.status(status).json({ error });
+    return;
+  }
+
+  res.json({ data: buildArtistOverview(artist.id) });
+});
+
+export default router;

--- a/src/services/aggregationService.js
+++ b/src/services/aggregationService.js
@@ -1,0 +1,323 @@
+import { artists } from '../data/artists.js';
+import { streamingServices } from '../data/mockServices.js';
+
+const defaultEngagement = { likes: 0, comments: 0, shares: 0 };
+const trendMetrics = ['streams', 'followers', 'revenue'];
+const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+const mergeEngagement = (acc, engagement) => ({
+  likes: acc.likes + (engagement?.likes ?? 0),
+  comments: acc.comments + (engagement?.comments ?? 0),
+  shares: acc.shares + (engagement?.shares ?? 0)
+});
+
+export const findArtistById = (artistId) => artists.find((artist) => artist.id === artistId);
+
+export const getServicesForArtist = (artist) => {
+  if (!artist) return [];
+
+  return streamingServices
+    .map((service) => {
+      if (!artist.services.includes(service.id)) return null;
+      const artistData = service.artists?.[artist.id];
+      if (!artistData) return null;
+
+      return {
+        id: service.id,
+        name: service.name,
+        ...artistData
+      };
+    })
+    .filter(Boolean);
+};
+
+export const aggregateMetrics = (services) => {
+  return services.reduce(
+    (acc, service) => {
+      const metrics = service.metrics ?? {};
+      return {
+        streams: acc.streams + (metrics.streams ?? 0),
+        followers: acc.followers + (metrics.followers ?? 0),
+        revenue: acc.revenue + (metrics.revenue ?? 0),
+        engagement: mergeEngagement(acc.engagement, metrics.engagement ?? defaultEngagement)
+      };
+    },
+    { streams: 0, followers: 0, revenue: 0, engagement: { ...defaultEngagement } }
+  );
+};
+
+export const aggregateAudienceInsights = (services) => {
+  const ageGroupTotals = {};
+  const ageGroupCounts = {};
+  const locations = new Set();
+  const interests = new Set();
+
+  services.forEach((service) => {
+    const audience = service.audience ?? {};
+    const ageGroups = audience.ageGroups ?? {};
+
+    Object.entries(ageGroups).forEach(([range, percentage]) => {
+      if (typeof percentage !== 'number') return;
+      ageGroupTotals[range] = (ageGroupTotals[range] ?? 0) + percentage;
+      ageGroupCounts[range] = (ageGroupCounts[range] ?? 0) + 1;
+    });
+
+    (audience.topLocations ?? []).forEach((location) => locations.add(location));
+    (audience.interests ?? []).forEach((interest) => interests.add(interest));
+  });
+
+  const ageGroupAverages = Object.entries(ageGroupTotals).reduce((acc, [range, total]) => {
+    const count = ageGroupCounts[range] ?? 1;
+    acc[range] = parseFloat((total / count).toFixed(2));
+    return acc;
+  }, {});
+
+  return {
+    ageGroups: ageGroupAverages,
+    topLocations: Array.from(locations),
+    interests: Array.from(interests)
+  };
+};
+
+export const aggregateContentPerformance = (services) => {
+  const tracks = new Set();
+  const albums = new Set();
+  const playlists = new Set();
+
+  services.forEach((service) => {
+    const topContent = service.topContent ?? {};
+    (topContent.tracks ?? []).forEach((track) => tracks.add(track));
+    (topContent.albums ?? []).forEach((album) => albums.add(album));
+    (topContent.playlists ?? []).forEach((playlist) => playlists.add(playlist));
+  });
+
+  return {
+    tracks: Array.from(tracks),
+    albums: Array.from(albums),
+    playlists: Array.from(playlists)
+  };
+};
+
+const sortByDateAsc = (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime();
+
+const parseAsDate = (value) => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const filterSeriesByRange = (series, startDate, endDate) => {
+  const start = parseAsDate(startDate);
+  const end = parseAsDate(endDate);
+
+  return series.filter((point) => {
+    const pointDate = parseAsDate(point.date);
+    if (!pointDate) return false;
+    if (start && pointDate < start) return false;
+    if (end && pointDate > end) return false;
+    return true;
+  });
+};
+
+const formatDate = (date) => {
+  if (!date) return null;
+  if (typeof date === 'string' && isoDateRegex.test(date)) return date;
+  const parsed = parseAsDate(date);
+  if (!parsed) return null;
+  return parsed.toISOString().slice(0, 10);
+};
+
+const summariseSeries = (series) => {
+  if (series.length === 0) {
+    return { total: 0, average: 0, change: null, points: 0 };
+  }
+
+  const total = series.reduce((sum, point) => sum + point.value, 0);
+  const average = parseFloat((total / series.length).toFixed(2));
+  const change =
+    series.length < 2
+      ? null
+      : parseFloat((series[series.length - 1].value - series[0].value).toFixed(2));
+
+  return {
+    total,
+    average,
+    change,
+    points: series.length
+  };
+};
+
+export const aggregateTrends = (services) => {
+  const totals = trendMetrics.reduce((acc, metric) => {
+    acc[metric] = new Map();
+    return acc;
+  }, {});
+
+  services.forEach((service) => {
+    trendMetrics.forEach((metric) => {
+      const series = service.trends?.[metric] ?? [];
+      series.forEach((point) => {
+        if (!point?.date || typeof point.value !== 'number') return;
+        const map = totals[metric];
+        map.set(point.date, (map.get(point.date) ?? 0) + point.value);
+      });
+    });
+  });
+
+  return trendMetrics.reduce(
+    (acc, metric) => {
+      const series = Array.from(totals[metric].entries())
+        .map(([date, value]) => ({ date, value }))
+        .sort(sortByDateAsc);
+      acc[metric] = series;
+      return acc;
+    },
+    { streams: [], followers: [], revenue: [] }
+  );
+};
+
+const deriveHeadlineInsights = (services, trends) => {
+  if (services.length === 0) {
+    return {
+      primaryPlatform: null,
+      mostRecentRevenue: null,
+      streamGrowthPercentage: null,
+      topTrack: null
+    };
+  }
+
+  const primaryPlatform = services.reduce((top, current) => {
+    const topStreams = top?.metrics?.streams ?? -Infinity;
+    const currentStreams = current.metrics?.streams ?? 0;
+    return currentStreams > topStreams ? current : top;
+  }, null);
+
+  const streamSeries = trends.streams ?? [];
+  const growthPercentage = (() => {
+    if (streamSeries.length < 2) return null;
+    const first = streamSeries[0].value;
+    const last = streamSeries[streamSeries.length - 1].value;
+    if (!first) return null;
+    return parseFloat((((last - first) / first) * 100).toFixed(2));
+  })();
+
+  const mostRecentRevenue = (() => {
+    const revenueSeries = trends.revenue ?? [];
+    if (revenueSeries.length === 0) return null;
+    return revenueSeries[revenueSeries.length - 1].value;
+  })();
+
+  const topTrack = services
+    .flatMap((service) => service.topContent?.tracks ?? [])
+    .reduce(
+      (top, track) => {
+        if (!top.seen.has(track)) {
+          top.seen.add(track);
+          top.order.push(track);
+        }
+        return top;
+      },
+      { seen: new Set(), order: [] }
+    ).order[0] ?? null;
+
+  return {
+    primaryPlatform: primaryPlatform ? { id: primaryPlatform.id, name: primaryPlatform.name } : null,
+    mostRecentRevenue,
+    streamGrowthPercentage: growthPercentage,
+    topTrack
+  };
+};
+
+export const buildArtistOverview = (artistId) => {
+  const artist = findArtistById(artistId);
+  if (!artist) return null;
+
+  const services = getServicesForArtist(artist);
+  const metrics = aggregateMetrics(services);
+  const audience = aggregateAudienceInsights(services);
+  const content = aggregateContentPerformance(services);
+  const trends = aggregateTrends(services);
+  const insights = deriveHeadlineInsights(services, trends);
+
+  return {
+    ...artist,
+    metrics,
+    audience,
+    content,
+    trends,
+    insights,
+    services: services.map((service) => ({
+      id: service.id,
+      name: service.name,
+      metrics: service.metrics,
+      audience: service.audience,
+      topContent: service.topContent,
+      trends: service.trends
+    }))
+  };
+};
+
+export const listArtistsWithSummaries = () =>
+  artists.map((artist) => {
+    const services = getServicesForArtist(artist);
+    const metrics = aggregateMetrics(services);
+    const insights = deriveHeadlineInsights(services, aggregateTrends(services));
+
+    return {
+      id: artist.id,
+      name: artist.name,
+      profileImage: artist.profileImage,
+      metrics: {
+        streams: metrics.streams,
+        followers: metrics.followers,
+        revenue: metrics.revenue
+      },
+      insights
+    };
+  });
+
+export const buildArtistMetricsSnapshot = (artistId, { startDate, endDate } = {}) => {
+  const artist = findArtistById(artistId);
+  if (!artist) return null;
+
+  const services = getServicesForArtist(artist);
+  const aggregatedTrends = aggregateTrends(services);
+
+  const filteredTrends = trendMetrics.reduce((acc, metric) => {
+    const series = aggregatedTrends[metric] ?? [];
+    acc[metric] = filterSeriesByRange(series, startDate, endDate);
+    return acc;
+  }, {});
+
+  const metrics = trendMetrics.reduce((acc, metric) => {
+    acc[metric] = summariseSeries(filteredTrends[metric]);
+    return acc;
+  }, {});
+
+  let minDate = null;
+  let maxDate = null;
+
+  trendMetrics.forEach((metric) => {
+    filteredTrends[metric].forEach((point) => {
+      const pointDate = parseAsDate(point.date);
+      if (!pointDate) return;
+      if (!minDate || pointDate < minDate) minDate = pointDate;
+      if (!maxDate || pointDate > maxDate) maxDate = pointDate;
+    });
+  });
+
+  return {
+    artist: {
+      id: artist.id,
+      name: artist.name
+    },
+    period: {
+      requestedStart: formatDate(startDate ?? null),
+      requestedEnd: formatDate(endDate ?? null),
+      actualStart: formatDate(minDate),
+      actualEnd: formatDate(maxDate)
+    },
+    metrics,
+    trends: filteredTrends
+  };
+};

--- a/src/services/dashboardService.js
+++ b/src/services/dashboardService.js
@@ -1,0 +1,110 @@
+import { artists } from '../data/artists.js';
+import { defaultLayout, initialDashboardLayouts, widgetCatalog } from '../data/dashboards.js';
+
+const MAX_WIDGETS = 8;
+const widgetIds = new Set(widgetCatalog.map((widget) => widget.id));
+const layoutStore = new Map(
+  Object.entries(initialDashboardLayouts).map(([artistId, layout]) => [artistId, [...layout]])
+);
+
+const cloneLayout = (layout) => [...layout];
+
+const sanitizeLayout = (layout) => {
+  const seen = new Set();
+  const sanitized = [];
+
+  layout.forEach((widgetId) => {
+    if (!widgetIds.has(widgetId)) return;
+    if (seen.has(widgetId)) return;
+    seen.add(widgetId);
+    sanitized.push(widgetId);
+  });
+
+  if (sanitized.length === 0) {
+    return cloneLayout(defaultLayout);
+  }
+
+  return sanitized;
+};
+
+const artistExists = (artistId) => artists.some((artist) => artist.id === artistId);
+
+const buildDashboardResponse = (layout) => ({
+  layout,
+  widgets: widgetCatalog
+});
+
+export const resetDashboardLayouts = () => {
+  layoutStore.clear();
+  Object.entries(initialDashboardLayouts).forEach(([artistId, layout]) => {
+    layoutStore.set(artistId, [...layout]);
+  });
+};
+
+export const getDashboard = (artistId) => {
+  if (!artistExists(artistId)) {
+    return { dashboard: null, error: `Artist with id "${artistId}" was not found.` };
+  }
+
+  const storedLayout = layoutStore.get(artistId) ?? cloneLayout(defaultLayout);
+  const layout = sanitizeLayout(storedLayout);
+  layoutStore.set(artistId, layout);
+
+  return { dashboard: buildDashboardResponse(layout), error: null };
+};
+
+export const updateDashboard = (artistId, payload) => {
+  if (!artistExists(artistId)) {
+    return { dashboard: null, error: `Artist with id "${artistId}" was not found.` };
+  }
+
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    return { dashboard: null, error: ['Provide the dashboard payload as an object.'] };
+  }
+
+  const { layout } = payload;
+  if (!Array.isArray(layout)) {
+    return { dashboard: null, error: ['Provide the "layout" array with widget identifiers.'] };
+  }
+
+  if (layout.length === 0) {
+    return { dashboard: null, error: ['Select at least one widget to compose the dashboard.'] };
+  }
+
+  if (layout.length > MAX_WIDGETS) {
+    return {
+      dashboard: null,
+      error: [`Dashboards suportam no máximo ${MAX_WIDGETS} widgets.`]
+    };
+  }
+
+  const errors = [];
+  const seen = new Set();
+  layout.forEach((widgetId) => {
+    if (typeof widgetId !== 'string') {
+      errors.push('Widget identifiers devem ser strings.');
+      return;
+    }
+
+    if (!widgetIds.has(widgetId)) {
+      errors.push(`Widget "${widgetId}" não é suportado.`);
+      return;
+    }
+
+    if (seen.has(widgetId)) {
+      errors.push(`Widget "${widgetId}" foi informado mais de uma vez.`);
+      return;
+    }
+
+    seen.add(widgetId);
+  });
+
+  if (errors.length > 0) {
+    return { dashboard: null, error: errors };
+  }
+
+  const sanitizedLayout = sanitizeLayout(layout);
+  layoutStore.set(artistId, sanitizedLayout);
+
+  return { dashboard: buildDashboardResponse(sanitizedLayout), error: null };
+};

--- a/src/services/profileService.js
+++ b/src/services/profileService.js
@@ -1,0 +1,124 @@
+import { artists } from '../data/artists.js';
+
+const allowedFields = new Set(['name', 'bio', 'profileImage', 'headerImage', 'socials']);
+const socialFields = ['instagram', 'twitter', 'youtube', 'facebook', 'tiktok', 'website'];
+
+const isString = (value) => typeof value === 'string';
+
+const isValidUrl = (value) => {
+  try {
+    new URL(value);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const validateProfileUpdates = (updates) => {
+  if (updates === null || typeof updates !== 'object' || Array.isArray(updates)) {
+    return ['Profile updates must be provided as an object.'];
+  }
+
+  const keys = Object.keys(updates);
+  if (keys.length === 0) {
+    return ['Provide at least one field to update.'];
+  }
+
+  const errors = [];
+
+  keys.forEach((key) => {
+    if (!allowedFields.has(key)) {
+      errors.push(`"${key}" is not a supported profile field.`);
+    }
+  });
+
+  if (updates.name !== undefined) {
+    if (!isString(updates.name)) {
+      errors.push('Name must be a string.');
+    } else if (updates.name.trim().length < 2 || updates.name.trim().length > 120) {
+      errors.push('Name must be between 2 and 120 characters.');
+    }
+  }
+
+  if (updates.bio !== undefined) {
+    if (!isString(updates.bio)) {
+      errors.push('Bio must be a string.');
+    } else if (updates.bio.length > 1000) {
+      errors.push('Bio must be 1000 characters or fewer.');
+    }
+  }
+
+  const validateImageField = (fieldName) => {
+    const value = updates[fieldName];
+    if (value === undefined) return;
+    if (!isString(value)) {
+      errors.push(`${fieldName} must be a string URL.`);
+      return;
+    }
+    if (!isValidUrl(value)) {
+      errors.push(`${fieldName} must be a valid URL.`);
+    }
+  };
+
+  validateImageField('profileImage');
+  validateImageField('headerImage');
+
+  if (updates.socials !== undefined) {
+    const socials = updates.socials;
+    if (socials === null || typeof socials !== 'object' || Array.isArray(socials)) {
+      errors.push('Social links must be provided as an object.');
+    } else {
+      const socialKeys = Object.keys(socials);
+      if (socialKeys.length === 0) {
+        errors.push('Provide at least one social link to update.');
+      }
+
+      socialKeys.forEach((socialKey) => {
+        if (!socialFields.includes(socialKey)) {
+          errors.push(`"${socialKey}" is not a supported social profile.`);
+          return;
+        }
+
+        const value = socials[socialKey];
+        if (!isString(value)) {
+          errors.push(`${socialKey} link must be a string.`);
+        } else if (!isValidUrl(value)) {
+          errors.push(`${socialKey} link must be a valid URL.`);
+        }
+      });
+    }
+  }
+
+  return errors;
+};
+
+export const updateArtistProfile = (artistId, updates) => {
+  const artistIndex = artists.findIndex((artist) => artist.id === artistId);
+  if (artistIndex === -1) {
+    return { artist: null, error: `Artist with id "${artistId}" was not found.` };
+  }
+
+  const validationErrors = validateProfileUpdates(updates);
+  if (validationErrors.length > 0) {
+    return {
+      artist: null,
+      error: validationErrors
+    };
+  }
+
+  const artist = artists[artistIndex];
+  const mergedSocials =
+    updates.socials !== undefined
+      ? { ...artist.socials, ...updates.socials }
+      : artist.socials;
+
+  const merged = {
+    ...artist,
+    ...updates,
+    socials: mergedSocials
+  };
+
+  artists[artistIndex] = merged;
+
+  return { artist: merged, error: null };
+};

--- a/test/aggregation.test.js
+++ b/test/aggregation.test.js
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  aggregateAudienceInsights,
+  aggregateContentPerformance,
+  aggregateMetrics,
+  aggregateTrends,
+  buildArtistOverview,
+  buildArtistMetricsSnapshot,
+  findArtistById,
+  getServicesForArtist,
+  listArtistsWithSummaries
+} from '../src/services/aggregationService.js';
+
+const getArtistServices = (artistId) => {
+  const artist = findArtistById(artistId);
+  assert.ok(artist, `Artist ${artistId} should exist for test setup`);
+  const services = getServicesForArtist(artist);
+  assert.ok(services.length > 0, `Expected artist ${artistId} to have services`);
+  return services;
+};
+
+test('findArtistById returns an existing artist', () => {
+  const artist = findArtistById('artist-001');
+  assert.ok(artist, 'Expected artist to be found');
+  assert.equal(artist.name, 'Lumen Echo');
+});
+
+test('getServicesForArtist returns configured services with nested data', () => {
+  const services = getArtistServices('artist-001');
+  const serviceIds = services.map((service) => service.id);
+  assert.deepEqual(serviceIds.sort(), ['apple', 'spotify', 'tidal']);
+  assert.ok(services.every((service) => service.metrics && service.topContent));
+});
+
+test('aggregateMetrics sums streams, followers, revenue, and engagement for an artist', () => {
+  const metrics = aggregateMetrics(getArtistServices('artist-001'));
+  assert.equal(metrics.streams, 1250000 + 840000 + 265000);
+  assert.equal(metrics.followers, 48200 + 22500 + 7800);
+  assert.equal(metrics.revenue, 34000 + 28500 + 13800);
+  assert.deepEqual(metrics.engagement, {
+    likes: 15200 + 9600 + 2800,
+    comments: 830 + 410 + 190,
+    shares: 1200 + 680 + 240
+  });
+});
+
+test('aggregateAudienceInsights averages percentages and merges sets', () => {
+  const audience = aggregateAudienceInsights(getArtistServices('artist-001'));
+  assert.equal(audience.ageGroups['18-24'], parseFloat(((0.32 + 0.27 + 0.22) / 3).toFixed(2)));
+  assert.ok(audience.topLocations.includes('United States'));
+  assert.ok(audience.interests.includes('Indie Pop'));
+});
+
+test('aggregateAudienceInsights ignores missing data when averaging', () => {
+  const services = [
+    { audience: { ageGroups: { '13-17': 0.12 } } },
+    { audience: { ageGroups: {} } }
+  ];
+
+  const audience = aggregateAudienceInsights(services);
+  assert.equal(audience.ageGroups['13-17'], 0.12);
+});
+
+test('aggregateContentPerformance merges unique content across services', () => {
+  const content = aggregateContentPerformance(getArtistServices('artist-001'));
+  assert.ok(content.tracks.includes('Neon Dreams'));
+  assert.ok(content.tracks.includes('Aurora'));
+  assert.ok(content.playlists.includes('Indie Radar'));
+});
+
+test('aggregateTrends sums timeline points across services and sorts by date', () => {
+  const trends = aggregateTrends(getArtistServices('artist-001'));
+  assert.equal(trends.streams[0].date, '2023-08-01');
+  assert.equal(
+    trends.streams.find((point) => point.date === '2024-01-01').value,
+    72000 + 47000 + 13000
+  );
+  assert.ok(trends.revenue.length > 0);
+});
+
+test('buildArtistOverview returns aggregated data with insights for artist', () => {
+  const overview = buildArtistOverview('artist-001');
+  assert.equal(overview.id, 'artist-001');
+  assert.equal(overview.metrics.streams, 1250000 + 840000 + 265000);
+  assert.equal(overview.trends.streams.length > 0, true);
+  assert.ok(overview.insights.primaryPlatform);
+});
+
+test('listArtistsWithSummaries returns summaries for every artist', () => {
+  const summaries = listArtistsWithSummaries();
+  assert.equal(summaries.length, 3);
+  const ids = summaries.map((summary) => summary.id).sort();
+  assert.deepEqual(ids, ['artist-001', 'artist-002', 'artist-003']);
+});
+
+test('buildArtistMetricsSnapshot returns totals, averages, and change for complete timeline', () => {
+  const artistId = 'artist-001';
+  const services = getArtistServices(artistId);
+  const aggregated = aggregateTrends(services);
+  const snapshot = buildArtistMetricsSnapshot(artistId);
+
+  assert.equal(snapshot.artist.id, artistId);
+  assert.deepEqual(snapshot.trends, aggregated);
+
+  const expectedTotals = aggregated.streams.reduce((sum, point) => sum + point.value, 0);
+  assert.equal(snapshot.metrics.streams.total, expectedTotals);
+  assert.equal(
+    snapshot.metrics.streams.change,
+    aggregated.streams[aggregated.streams.length - 1].value - aggregated.streams[0].value
+  );
+  assert.equal(snapshot.metrics.streams.points, aggregated.streams.length);
+  assert.equal(snapshot.period.actualStart, aggregated.streams[0].date);
+  assert.equal(
+    snapshot.period.actualEnd,
+    aggregated.streams[aggregated.streams.length - 1].date
+  );
+});
+
+test('buildArtistMetricsSnapshot filters series by provided range', () => {
+  const artistId = 'artist-002';
+  const startDate = new Date('2023-10-01');
+  const endDate = new Date('2023-12-01');
+  const snapshot = buildArtistMetricsSnapshot(artistId, { startDate, endDate });
+
+  assert.equal(snapshot.period.requestedStart, '2023-10-01');
+  assert.equal(snapshot.period.requestedEnd, '2023-12-01');
+  assert.equal(snapshot.period.actualStart, '2023-10-01');
+  assert.equal(snapshot.period.actualEnd, '2023-12-01');
+
+  const series = snapshot.trends.streams;
+  assert.ok(series.every((point) => point.date >= '2023-10-01' && point.date <= '2023-12-01'));
+  assert.equal(series.length > 0, true);
+  const total = series.reduce((sum, point) => sum + point.value, 0);
+  assert.equal(snapshot.metrics.streams.total, total);
+});
+
+test('buildArtistMetricsSnapshot returns zeroed metrics when range has no data', () => {
+  const snapshot = buildArtistMetricsSnapshot('artist-003', {
+    startDate: new Date('2030-01-01'),
+    endDate: new Date('2030-12-31')
+  });
+
+  assert.equal(snapshot.trends.streams.length, 0);
+  assert.deepEqual(snapshot.metrics.streams, { total: 0, average: 0, change: null, points: 0 });
+  assert.equal(snapshot.period.actualStart, null);
+  assert.equal(snapshot.period.actualEnd, null);
+});

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDashboard, resetDashboardLayouts, updateDashboard } from '../src/services/dashboardService.js';
+
+const setup = () => {
+  resetDashboardLayouts();
+};
+
+test('getDashboard returns stored layout and widget catalog', () => {
+  setup();
+  const { dashboard, error } = getDashboard('artist-001');
+  assert.equal(error, null);
+  assert.ok(Array.isArray(dashboard.layout));
+  assert.ok(dashboard.layout.includes('streams-over-time'));
+  assert.ok(Array.isArray(dashboard.widgets));
+});
+
+test('getDashboard returns not found error for unknown artist', () => {
+  setup();
+  const { dashboard, error } = getDashboard('missing-artist');
+  assert.equal(dashboard, null);
+  assert.equal(typeof error, 'string');
+  assert.ok(error.includes('missing-artist'));
+});
+
+test('updateDashboard validates layout payload', () => {
+  setup();
+  const { dashboard: invalidDashboard, error: invalidError } = updateDashboard('artist-001', {
+    layout: ['overview', 'overview']
+  });
+  assert.equal(invalidDashboard, null);
+  assert.ok(Array.isArray(invalidError));
+  assert.ok(invalidError.some((message) => message.includes('mais de uma vez')));
+
+  const { dashboard, error } = updateDashboard('artist-001', {
+    layout: ['overview', 'streams-over-time']
+  });
+  assert.equal(error, null);
+  assert.deepEqual(dashboard.layout, ['overview', 'streams-over-time']);
+});
+
+test('updateDashboard limits maximum widgets', () => {
+  setup();
+  const { error } = updateDashboard('artist-001', {
+    layout: ['overview', 'streams-over-time', 'revenue-over-time', 'audience-demographics', 'top-content', 'top-locations', 'overview', 'streams-over-time', 'top-content']
+  });
+  assert.ok(Array.isArray(error));
+  assert.ok(error[0].includes('máximo'));
+});

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { artists } from '../src/data/artists.js';
+import { updateArtistProfile } from '../src/services/profileService.js';
+
+const originalArtists = structuredClone(artists);
+
+const resetArtists = () => {
+  artists.length = 0;
+  artists.push(...structuredClone(originalArtists));
+};
+
+test('updateArtistProfile rejects empty payloads', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', {});
+  assert.equal(result.artist, null);
+  assert.ok(Array.isArray(result.error));
+  assert.ok(result.error.some((message) => message.toLowerCase().includes('at least one field')));
+});
+
+test('updateArtistProfile validates social handles object is not empty', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', { socials: {} });
+  assert.equal(result.artist, null);
+  assert.ok(result.error.some((message) => message.toLowerCase().includes('social link')));
+});
+
+test('updateArtistProfile merges social links when valid', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', {
+    socials: { instagram: 'https://instagram.com/new-handle' }
+  });
+
+  assert.equal(result.error, null);
+  assert.equal(result.artist.socials.instagram, 'https://instagram.com/new-handle');
+  assert.equal(result.artist.socials.youtube, originalArtists[0].socials.youtube);
+});
+
+test('updateArtistProfile leaves existing socials untouched when not provided', () => {
+  resetArtists();
+  const result = updateArtistProfile('artist-001', {
+    bio: 'Updated bio only'
+  });
+
+  assert.equal(result.error, null);
+  assert.equal(result.artist.bio, 'Updated bio only');
+  assert.deepEqual(result.artist.socials, originalArtists[0].socials);
+});


### PR DESCRIPTION
## Summary
- expand the mock dataset to three artists with per-service metrics, trends, and richer insight aggregation helpers
- add dashboard layout storage plus GET/PUT endpoints so artists can retrieve and customize their widgets
- refresh documentation and tests to reflect the new data structures, dashboard flows, and trend aggregation logic
- expose an aggregated metrics snapshot endpoint with optional date filtering and document the new API surface alongside regression tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dffbc657dc83239e6e0b7f82c4e4a9